### PR TITLE
"File extension is not recognized" on uppercase

### DIFF
--- a/SmartImage/Searching/Search.cs
+++ b/SmartImage/Searching/Search.cs
@@ -198,7 +198,7 @@ namespace SmartImage.Searching
 				return false;
 			}
 
-			bool extOkay = ImageExtensions.Any(img.EndsWith);
+			bool extOkay = ImageExtensions.Any(img.ToLower().EndsWith);
 
 			if (!extOkay) {
 				return CliOutput.ReadConfirm("File extension is not recognized as a common image format. Continue?");


### PR DESCRIPTION
Fixes "File extension is not recognized as a common image format. Continue?" error when filename extension is uppercase (.JPG). Now, it doesn't throw that error.