### PR TITLE
fix: headless/non-interactive Rdx for bots (cast + empty output file)

### DIFF
--- a/SmartImage.Rdx/Commands/Search/SearchCommand.cs
+++ b/SmartImage.Rdx/Commands/Search/SearchCommand.cs
@@ -98,8 +98,12 @@ public sealed partial class SearchCommand : CommonAsyncCommand<SearchCommandSett
 		if (!url) {
 			throw new SmartImageException($"Could not upload {Query}");
 		}
-		
-		m_queryCanvasImg = new CanvasImage(Query.Source.GetSource());
+
+		// CanvasImage preview is only needed for interactive UI. Building it
+		// headless has thrown on some image sources; skip when not interactive.
+		if (CommandSettings.Interactive) {
+			m_queryCanvasImg = new CanvasImage(Query.Source.GetSource());
+		}
 
 		p.Increment(Elements.COMPLETE / 2);
 
@@ -171,28 +175,25 @@ public sealed partial class SearchCommand : CommonAsyncCommand<SearchCommandSett
 		while (!ct.IsCancellationRequested && await Client.ResultChannel.Reader.WaitToReadAsync(ct)) {
 			var result = await Client.ResultChannel.Reader.ReadAsync(ct);
 
+			// Always collect for WriteOutputFile (interactive and headless).
+			// Previously non-interactive mode never filled m_dialogs, so -o files
+			// were empty even when the search succeeded.
+			m_dialogs.TryAdd(result, ResultViewState.Create(result));
 
 			if (CommandSettings.Interactive) {
-
-				m_dialogs.TryAdd(result, ResultViewState.Create(result));
-
 				m_mainTable.AddRow(result.GetMainRows());
 				Elements.Prm_SearchResult.AddChoice(result);
-
 			}
 			else {
-
+				// GetMainRows returns IList<IRenderable> (a List), not IRenderable[].
+				// The old cast threw InvalidCastException after upload on Linux headless.
 				var fullRows = result.GetFullRows();
-
 				foreach (var list in fullRows) {
-					var row = (IRenderable[]) list;
-					m_mainTable.AddRow(row);
+					m_mainTable.AddRow(list.ToArray());
 				}
 			}
 
-
 			c.Refresh();
-
 		}
 
 		await searchTask;

--- a/SmartImage.Rdx/Program.cs
+++ b/SmartImage.Rdx/Program.cs
@@ -104,7 +104,9 @@ public static class Program
 		}
 		finally {
 
-			if (x != Common.EC_OK) {
+			// Never block on a prompt when stdin is redirected / non-interactive
+			// (bots, Docker, CI). ConfirmAsync crashes with Failed to read input.
+			if (x != Common.EC_OK && !Console.IsInputRedirected) {
 				await AnsiConsole.ConfirmAsync("Press any key to continue");
 			}
 		}
@@ -186,13 +188,17 @@ public static class Program
 
 			var pipeInput = ConsoleUtil.ParseInputStream();
 
-			var newArgs = new string[args.Length + 1];
-			newArgs[0] = pipeInput;
-			args.CopyTo(newArgs, 1);
+			// Ignore empty redirects (DEVNULL / closed pipe) so headless bots
+			// can pass the query solely via argv.
+			if (!String.IsNullOrWhiteSpace(pipeInput)) {
+				var newArgs = new string[args.Length + 1];
+				newArgs[0] = pipeInput;
+				args.CopyTo(newArgs, 1);
 
-			args = newArgs;
+				args = newArgs;
 
-			AnsiConsole.WriteLine($"Received input from stdin");
+				AnsiConsole.WriteLine($"Received input from stdin");
+			}
 		}
 #endif
 

--- a/SmartImage.Rdx/Shell/ConsoleUtil.cs
+++ b/SmartImage.Rdx/Shell/ConsoleUtil.cs
@@ -36,7 +36,8 @@ internal static class ConsoleUtil
 		while ((bytesRead = stdin.Read(buffer, 0, buffer.Length)) > 0) {
 			if (iter == 0) {
 
-				if (buffer[0]    == s_utf8BomSig[0]
+				if (bytesRead >= 3
+				    && buffer[0] == s_utf8BomSig[0]
 				    && buffer[1] == s_utf8BomSig[1]
 				    && buffer[2] == s_utf8BomSig[2]) {
 
@@ -53,7 +54,12 @@ internal static class ConsoleUtil
 			// prog?.Report(b2pos);
 		}
 
-		if (buffer2[(b2pos - 1)] == '\n' && buffer2[(b2pos - 2)] == '\r') {
+		// Empty redirected stdin (e.g. DEVNULL) used to IndexOutOfRange on b2pos-1.
+		if (b2pos == 0) {
+			return null;
+		}
+
+		if (b2pos >= 2 && buffer2[(b2pos - 1)] == '\n' && buffer2[(b2pos - 2)] == '\r') {
 			b2pos -= 2;
 		}
 


### PR DESCRIPTION
## Summary
Fixes three bugs that make **SmartImage.Rdx unusable as a headless server backend** (Telegram bots, Docker, CI):

1. **InvalidCastException** after upload in non-interactive mode: `(IRenderable[]) list` where `list` is `IList<IRenderable>` / `List` from `GetMainRows`.
2. **Empty `--output-file`**: `WriteOutputFile` only walks `m_dialogs`, which was only populated when `Interactive` was true.
3. **Empty redirected stdin** crash in `ParseInputStream` (`buffer2[-1]`), and **ConfirmAsync** hanging/crashing on error when stdin is DEVNULL.

## Test plan
- [ ] `SmartImage photo.jpg -e SauceNao -u Catbox -f Delimited -o out.tsv --interactive false --keep-open false </dev/null`
- [ ] Expect exit without Spectre cast crash; `out.tsv` has header + rows when matches exist
- [ ] Interactive mode still behaves as before

Used by [crl33/ReverseImageSearching](https://github.com/crl33/ReverseImageSearching) Telegram bot behind BotDashboard.